### PR TITLE
Fix CPF: Remove access syntax with curly braces

### DIFF
--- a/cpf
+++ b/cpf
@@ -3,7 +3,7 @@
 $cpf = substr((empty($argv[1])?'':$argv[1]) . str_pad(rand(1, 999999998), 9, '0', STR_PAD_LEFT), 0, 9);
 for ($t = 9; $t < 11; $t++) {
 	for ($d = 0, $c = 0; $c < $t; $c++)
-		$d += $cpf{$c} * (($t + 1) - $c);
+		$d += $cpf[$c] * (($t + 1) - $c);
 	$cpf .= ((10 * $d) % 11) % 10;
 }
 echo $cpf."\n";


### PR DESCRIPTION
Hi :) Nice to meet you, this is a pretty cool repo with some wild scripts.

I didn't understand what cpf did until I tried to run it, and I got this error
```bash
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /home/vacation/Desktop/interface/cpf.php on line 6
```
Kinda funny the last commit on the file was "update to modern php" maybe we need to update _again_?
My php

```bash
PHP 8.2.6 (cli) (built: May  9 2023 16:47:59) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.6, Copyright (c) Zend Technologies
```

replacing `{}` with `[]` worked, and I found out that this is a CPF generator :D pretty cool.

I don't know any PHP, does this make sense?

additionally, thoughts on renaming to cpf-gen or something? 